### PR TITLE
Fixed login_headertitle depreciated error

### DIFF
--- a/pixelnib-login.php
+++ b/pixelnib-login.php
@@ -33,7 +33,7 @@ function pixelnib_login_logo_title() {
     return 'PixelNib';
 }
 
-add_action ('login_headertitle', 'pixelnib_login_logo_title');
+add_action ('login_headertext', 'pixelnib_login_logo_title');
 
 // Change login URL
 function pixelnib_login_log_url() {


### PR DESCRIPTION
 login_headertitle has been deprecated since version 5.2.0. Usage of the title attribute on the login logo is not recommended for accessibility reasons. That's why use login_headertext instead.